### PR TITLE
Fix issue if incorrect translation returns type different than string

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -89,7 +89,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 		// If the line doesn't exist, we will return back the key which was requested as
 		// that will be quick to spot in the UI if language keys are wrong or missing
 		// from the application's language files. Otherwise we can return the line.
-		if ( ! isset($line)) return $key;
+		if(!isset($line) || gettype($line) != 'string') return $key;
 
 		return $line;
 	}


### PR DESCRIPTION
This pull request fixes an issue when an incorrect translation returns type different than string (ee.g. array) that will cause an ErrorException Array to string conversion.
This might happen when, for instance, the correct translation key would be:  
```php
// correct key
trans("user.messages.welcome")
// incorrect key in code it's found
trans("user.messages")
```